### PR TITLE
Do not load URDF twice

### DIFF
--- a/launch/includes/spawn_mobile_manipulator.launch
+++ b/launch/includes/spawn_mobile_manipulator.launch
@@ -62,6 +62,7 @@
 
             <!-- MoveIt! Main -->
             <include file="$(find panda_moveit_config)/launch/move_group.launch">
+                  <arg name="load_robot_description" value="false"/>
                   <arg name="info" value="true"/>
                   <arg name="debug" value="false"/>
             </include>


### PR DESCRIPTION
Due to changed defaults in panda_moveit_config the URDF was loaded twice (incorrectly), fixes #1